### PR TITLE
タイマー開始時にいきなり１秒追加される不具合を修正

### DIFF
--- a/timerApp/app/src/main/java/com/example/timerapp/MainActivity.kt
+++ b/timerApp/app/src/main/java/com/example/timerapp/MainActivity.kt
@@ -44,7 +44,8 @@ class MainActivity : AppCompatActivity() {
 
         bt_start.setOnClickListener { it: View? ->
             if (Prflg == true) {
-                handler.post(runnable)
+//                handler.post(runnable)
+                handler.postDelayed(runnable, 1000)
 
                 bt_start.text = getString(R.string.stop_val)
                 bt_start.setBackgroundColor(Color.rgb(0xFF,0x68,0x00))


### PR DESCRIPTION
試しに修正コードの取り込み依頼（プルリクエスト）投げてみました。
bt_startが押下されたとき、直後にHanderを走らせているので1秒からカウント開始になってました。

うまく起動できなくなっているのはエラーログ見た感じ、GoogleAdsの設定が済んでいないからですね。ManifestファイルにIDとか追記する必要がある感じですかね？また調べてみてください！

Signed-off-by: shimo3 <shimo3@vega.ocn.ne.jp>